### PR TITLE
Rename Type Columns to exclude the word "Column"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ module.exports = {
       id: new FieldBuilder().primaryKey().output(),
 
       firstName: new FieldBuilder()
-        .stringColumn()
+        .string()
         .allowNull()
         .output(),
 
       lastName: new FieldBuilder()
-        .stringColumn()
+        .string()
         .allowNull()
         .output(),
 
       email: new FieldBuilder()
-        .emailColumn()
+        .email()
         .allowNull()
         .unique()
         .output()
@@ -124,7 +124,7 @@ module.exports = {
       id: new FieldBuilder().primaryKey().output(),
 
       firstName: new FieldBuilder()
-        .stringColumn()
+        .string()
         .allowNull()
         .output(),
   },
@@ -141,11 +141,11 @@ At the core each column should instantiate a new instance of the `FieldBuilder` 
 firstName: new FieldBuilder()
 ```
 
-Once you have the class, you will have access to all the functions available to that class (see docs below for full list). For example, calling the `stringColumn()` and `allowNull()` will add the `Sequelize.STRING` type and set the `allowNull` property to false which results in a required string field:
+Once you have the class, you will have access to all the functions available to that class (see docs below for full list). For example, calling the `string()` and `allowNull()` will add the `Sequelize.STRING` type and set the `allowNull` property to false which results in a required string field:
 
 ```js
 firstName: new FieldBuilder()
-  .stringColumn()
+  .string()
   .allowNull()
 ```
 
@@ -153,7 +153,7 @@ Finally, the last function you will need to call is `output()`, which will outpu
 
 ```js
 firstName: new FieldBuilder()
-  .stringColumn()
+  .string()
   .allowNull()
   .output()
 
@@ -183,11 +183,11 @@ The following functions configure a column by setting the `type` property on the
 
 Marks a column for storing boolean values.
 
-Usage: `FieldBuilder.booleanColumn()`
+Usage: `FieldBuilder.boolean()`
 
 Example:
 ```js
-field: FieldBuilder.booleanColumn().output();
+field: FieldBuilder.boolean().output();
 
 // Output
 // field: {
@@ -199,11 +199,11 @@ field: FieldBuilder.booleanColumn().output();
 
 Marks a column for storing date values.  Note that this is the simplest date option provided by Sequelize.  Other date based types can be found in their [documentation](https://sequelize.org/docs/v7/other-topics/other-data-types/#dates).
 
-Usage: `FieldBuilder.dateColumn()`
+Usage: `FieldBuilder.date()`
 
 Example:
 ```js
-field: FieldBuilder.booleanColumn().output();
+field: FieldBuilder.boolean().output();
 
 // Output
 // field: {
@@ -215,11 +215,11 @@ field: FieldBuilder.booleanColumn().output();
 
 Marks the column as a string _and_ assigns the `isEmail` validation condition.  This is one of the many validators provided by sequelize
 
-Usage: `FieldBuilder.emailColumn()`
+Usage: `FieldBuilder.email()`
 
 Example:
 ```js
-field: FieldBuilder.booleanColumn().output();
+field: FieldBuilder.boolean().output();
 
 // Output
 // field: {
@@ -234,11 +234,11 @@ field: FieldBuilder.booleanColumn().output();
 
 Configures a column to accept a set of accepted values.  This is a list of strings either as a list of parameters or as an array of strings.
 
-Usage: `FieldBuilder.enumColumn(...options: string)`
+Usage: `FieldBuilder.enum(...options: string)`
 
 Example:
 ```js
-field: FieldBuilder.enumColumn('pending', 'active', 'complete').output();
+field: FieldBuilder.enum('pending', 'active', 'complete').output();
 
 // Output
 // field: {
@@ -249,7 +249,7 @@ field: FieldBuilder.enumColumn('pending', 'active', 'complete').output();
 
 ```js
 const status = ['pending', 'active', 'complete']
-field: FieldBuilder.enumColumn(status);
+field: FieldBuilder.enum(status);
 
 // Output
 // field: {
@@ -303,11 +303,11 @@ field: FieldBuilder.foreignKey('Users_Addresses', 'userId);
 
 Marks a column for storing JSON data.  Full details can be found in the [documentation](https://sequelize.org/docs/v6/other-topics/other-data-types/#json-sqlite-mysql-mariadb-and-postgresql-only).
 
-Usage: `FieldBuilder.jsonColumn(defaultValue?: Record<string,any>)`
+Usage: `FieldBuilder.json(defaultValue?: Record<string,any>)`
 
 Example:
 ```js
-field: FieldBuilder.jsonColumn().output();
+field: FieldBuilder.json().output();
 
 // Output
 // field: {
@@ -320,11 +320,11 @@ field: FieldBuilder.jsonColumn().output();
 
 Marks a column for various types of numbers. 
 
-Usage: `FieldBuilder.numberColumn(type?: string)`
+Usage: `FieldBuilder.number(type?: string)`
 
 Example:
 ```js
-field: FieldBuilder.numberColumn().output();
+field: FieldBuilder.number().output();
 
 // Output
 // field: {
@@ -350,7 +350,7 @@ Usage: `FieldBuilder.primaryKey()`
 
 Example:
 ```js
-field: FieldBuilder.numberColumn().output();
+field: FieldBuilder.number().output();
 
 // Output
 // field: {
@@ -365,11 +365,11 @@ field: FieldBuilder.numberColumn().output();
 
 Marks a column for storing smaller strings.  Per the [documentation](https://sequelize.org/docs/v7/other-topics/other-data-types/#strings), Sequelize will create a `VARCHAR` type with a 255 character max.
 
-Usage: `FieldBuilder.stringColumn()`
+Usage: `FieldBuilder.string()`
 
 Example:
 ```js
-field: FieldBuilder.stringColumn().output();
+field: FieldBuilder.string().output();
 
 // Output
 // field: {
@@ -381,11 +381,11 @@ field: FieldBuilder.stringColumn().output();
 
 Marks a column for storing larger strings.  Depending on your database, Sequelize will use that flavor syntax to generate the field.  The max size will depend on the database and it is recommended that you review the [documentation](https://sequelize.org/docs/v7/other-topics/other-data-types/#strings).
 
-Usage: `FieldBuilder.textColumn()`
+Usage: `FieldBuilder.text()`
 
 Example:
 ```js
-field: FieldBuilder.textColumn().output();
+field: FieldBuilder.text().output();
 
 // Output
 // field: {
@@ -435,7 +435,7 @@ Example:
 // Set default value on a string column to `None`
 
 FieldBuilder
-  .stringColumn()
+  .string()
   .defaultValue('None');
 
 // Output
@@ -580,8 +580,8 @@ up(queryInstance, Sequelize) {
   await queryInterface.createTable('Users', {
     id: new FieldBuilder().primaryKey().output();
 
-    name: new FieldBuilder().stringColumn().unique('user_info').output()
-    email: new FieldBuilder().emailColumn().unique('user_info')
+    name: new FieldBuilder().string().unique('user_info').output()
+    email: new FieldBuilder().email().unique('user_info')
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = class FieldBuilder {
    * Sets the type of a column as a boolean
    * @returns {FieldBuilder} The builder instance
    */
-  booleanColumn() {
+  boolean() {
     Object.assign(this.fieldState, { type: Sequelize.BOOLEAN });
     return this;
   }
@@ -30,7 +30,7 @@ module.exports = class FieldBuilder {
    * Sets the type of a column as a date
    * @returns {FieldBuilder} The builder instance 
    */
-  dateColumn() {
+  date() {
     Object.assign(this.fieldState, { type: Sequelize.DATE });
     return this;
   }
@@ -53,7 +53,7 @@ module.exports = class FieldBuilder {
    * Applies the STRING type and email validation flag to the column
    * @returns {FieldBuilder} The builder instance
    */
-  emailColumn() {
+  email() {
     Object.assign(this.fieldState, {
       type: Sequelize.STRING
     });
@@ -76,7 +76,7 @@ module.exports = class FieldBuilder {
    * @param {string[]} options List of valid string options 
    * @returns {FieldBuilder} The builder instance
    */
-  enumColumn(...options) {
+  enum(...options) {
     const values = options.flat();
 
     if (!values.length) {
@@ -118,7 +118,7 @@ module.exports = class FieldBuilder {
    * @param {Record<string, any>} [defaultValue={}] Default value to be assigned to fields 
    * @returns {FieldBuilder} The builder instance 
    */
-  jsonColumn(defaultValue = {}) {
+  json(defaultValue = {}) {
 
     if (typeof defaultValue !== 'object') {
       throw new Error('Default value must be an object');
@@ -207,13 +207,13 @@ module.exports = class FieldBuilder {
    */
   static statusColumns() {
     return {
-      active: new FieldBuilder().booleanColumn().output(),
-      created_at: new FieldBuilder().dateColumn().required().output(),
-      updated_at: new FieldBuilder().dateColumn().required().output(),
+      active: new FieldBuilder().boolean().output(),
+      created_at: new FieldBuilder().date().required().output(),
+      updated_at: new FieldBuilder().date().required().output(),
     }
   }
 
-  stringColumn() {
+  string() {
     Object.assign(this.fieldState, {
       type: Sequelize.STRING,
       default: "",
@@ -221,7 +221,7 @@ module.exports = class FieldBuilder {
     return this;
   }
 
-  textColumn() {
+  text() {
     Object.assign(this.fieldState, {
       type: Sequelize.TEXT,
       default: "",

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = class FieldBuilder {
    * @param { 'bigint' | 'double' | 'float' | 'integer' | 'smallint'} [typeSelection] The type of integer
    * @returns {FieldBuilder} The builder instance 
    */
-  numberColumn(typeSelection = 'integer') {
+  number(typeSelection = 'integer') {
     const typeMap = {
       'bigint': Sequelize.BIGINT,
       'double': Sequelize.DOUBLE,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.BOOLEAN`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.booleanColumn().output())
+      expect(builder.boolean().output())
         .to.deep.eq({ type: Sequelize.BOOLEAN })
     })
   });
@@ -39,7 +39,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.DATE`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.dateColumn().output())
+      expect(builder.date().output())
         .to.deep.eq({ type: Sequelize.DATE })
     })
   });
@@ -63,14 +63,14 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.STRING` and the email validation', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.emailColumn().output())
+      expect(builder.email().output())
         .to.deep.eq({ type: Sequelize.STRING, validate: { isEmail: true } });
     });
 
     it('should append to the validate object when one already exists', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.nonEmptyString().emailColumn().output())
+      expect(builder.nonEmptyString().email().output())
         .to.deep.eq({ type: Sequelize.STRING, validate: { notEmpty: true, isEmail: true } });
     });
   });
@@ -79,7 +79,7 @@ describe('FieldBuilder', () => {
     it('should accept a list of params and apply them', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.enumColumn('pending', 'active', 'complete').output())
+      expect(builder.enum('pending', 'active', 'complete').output())
         .to.deep.eq({ type: Sequelize.ENUM, values: [ 'pending', 'active', 'complete' ] });
     });
 
@@ -87,7 +87,7 @@ describe('FieldBuilder', () => {
       const builder = new FieldBuilder();
       const statusArray = ['pending', 'active', 'complete'];
 
-      expect(builder.enumColumn(statusArray).output())
+      expect(builder.enum(statusArray).output())
         .to.deep.eq({ type: Sequelize.ENUM, values: [ 'pending', 'active', 'complete' ] });
     });
 
@@ -143,7 +143,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.JSON`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.jsonColumn().output())
+      expect(builder.json().output())
         .to.deep.eq({ type: Sequelize.JSON, default: {} });
     });
 
@@ -151,25 +151,25 @@ describe('FieldBuilder', () => {
       const builder = new FieldBuilder();
 
       try {
-        builder.jsonColumn('default')
+        builder.json('default')
       } catch (error) {
         expect(error.message).to.be.eq('Default value must be an object');
       }
 
       try {
-        builder.jsonColumn(0)
+        builder.json(0)
       } catch (error) {
         expect(error.message).to.be.eq('Default value must be an object');
       }
 
       try {
-        builder.jsonColumn()
+        builder.json()
       } catch (error) {
         expect(error.message).to.be.eq('Default value must be an object');
       }
 
       try {
-        builder.jsonColumn(null)
+        builder.json(null)
       } catch (error) {
         expect(error.message).to.be.eq('Default value must be an object');
       }
@@ -188,7 +188,7 @@ describe('FieldBuilder', () => {
     it('should append to the validate object when one already exists', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.emailColumn().nonEmptyString().output())
+      expect(builder.email().nonEmptyString().output())
         .to.deep.eq({ type: Sequelize.STRING, validate: { notEmpty: true, isEmail: true } });
     });
   });
@@ -197,42 +197,42 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.INTEGER`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn().output())
+      expect(builder.number().output())
         .to.deep.eq({ type: Sequelize.INTEGER })
     });
 
     it('should set the type of the field as `Sequelize.BIGINT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn('bigint').output())
+      expect(builder.number('bigint').output())
         .to.deep.eq({ type: Sequelize.BIGINT })
     });
 
     it('should set the type of the field as `Sequelize.DOUBLE`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn('double').output())
+      expect(builder.number('double').output())
         .to.deep.eq({ type: Sequelize.DOUBLE })
     });
     
     it('should set the type of the field as `Sequelize.FLOAT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn('float').output())
+      expect(builder.number('float').output())
         .to.deep.eq({ type: Sequelize.FLOAT })
     });
 
     it('should set the type of the field as `Sequelize.INTEGER`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn('integer').output())
+      expect(builder.number('integer').output())
         .to.deep.eq({ type: Sequelize.INTEGER })
     });
 
     it('should set the type of the field as `Sequelize.smallint`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.numberColumn('smallint').output())
+      expect(builder.number('smallint').output())
         .to.deep.eq({ type: Sequelize.SMALLINT })
     });
     
@@ -285,7 +285,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.STRING`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.stringColumn().output())
+      expect(builder.string().output())
         .to.deep.eq({ type: Sequelize.STRING, default: "" })
     })
   });
@@ -294,7 +294,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.TEXT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.textColumn().output())
+      expect(builder.text().output())
         .to.deep.eq({ type: Sequelize.TEXT, default: "" })
     })
   });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -94,7 +94,7 @@ describe('FieldBuilder', () => {
     it('should throw an error if there are no items', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.enumColumn).to.throw('Enums cannot be empty', []);
+      expect(builder.enum).to.throw('Enums cannot be empty', []);
     });
   });
 


### PR DESCRIPTION
**Description**

Got some feedback in an issue that the word "Column" was redundant.  After thinking about this I have to agree.  It is clear what we are doing with the functions without needing to add the word "Column"

Closes #3 