### PR TITLE
Feature: Remove Output Fn Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,20 @@ const FieldBuilder = require('./utils/migration.utils');
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('Users', {
-      id: new FieldBuilder().primaryKey().output(),
+      id: new FieldBuilder().primaryKey(),
 
       firstName: new FieldBuilder()
         .string()
-        .allowNull()
-        .output(),
+        .allowNull(),
 
       lastName: new FieldBuilder()
         .string()
-        .allowNull()
-        .output(),
+        .allowNull(),
 
       email: new FieldBuilder()
         .email()
         .allowNull()
-        .unique()
-        .output()
+        .unique(),
 
       password: new FieldBuilder()
     });
@@ -121,12 +118,11 @@ const FieldBuilder = require('./utils/migration.utils');
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('Users', {
-      id: new FieldBuilder().primaryKey().output(),
+      id: new FieldBuilder().primaryKey(),
 
       firstName: new FieldBuilder()
         .string()
-        .allowNull()
-        .output(),
+        .allowNull(),
   },
 
   async down(queryInterface, Sequelize) {
@@ -147,15 +143,6 @@ Once you have the class, you will have access to all the functions available to 
 firstName: new FieldBuilder()
   .string()
   .allowNull()
-```
-
-Finally, the last function you will need to call is `output()`, which will output a JSON object based on state of the builder:
-
-```js
-firstName: new FieldBuilder()
-  .string()
-  .allowNull()
-  .output()
 
 
 // Output:
@@ -187,7 +174,7 @@ Usage: `FieldBuilder.boolean()`
 
 Example:
 ```js
-field: FieldBuilder.boolean().output();
+field: FieldBuilder.boolean();
 
 // Output
 // field: {
@@ -203,7 +190,7 @@ Usage: `FieldBuilder.date()`
 
 Example:
 ```js
-field: FieldBuilder.boolean().output();
+field: FieldBuilder.boolean();
 
 // Output
 // field: {
@@ -219,7 +206,7 @@ Usage: `FieldBuilder.email()`
 
 Example:
 ```js
-field: FieldBuilder.boolean().output();
+field: FieldBuilder.boolean();
 
 // Output
 // field: {
@@ -238,7 +225,7 @@ Usage: `FieldBuilder.enum(...options: string)`
 
 Example:
 ```js
-field: FieldBuilder.enum('pending', 'active', 'complete').output();
+field: FieldBuilder.enum('pending', 'active', 'complete');
 
 // Output
 // field: {
@@ -268,7 +255,7 @@ Example:
 ```js
 // Ties this table to another table called `Addresses`
 
-field: FieldBuilder.foreignKey('Addresses').output();
+field: FieldBuilder.foreignKey('Addresses');
 
 // Output
 // field: {
@@ -307,7 +294,7 @@ Usage: `FieldBuilder.json(defaultValue?: Record<string,any>)`
 
 Example:
 ```js
-field: FieldBuilder.json().output();
+field: FieldBuilder.json();
 
 // Output
 // field: {
@@ -324,7 +311,7 @@ Usage: `FieldBuilder.number(type?: string)`
 
 Example:
 ```js
-field: FieldBuilder.number().output();
+field: FieldBuilder.number();
 
 // Output
 // field: {
@@ -350,7 +337,7 @@ Usage: `FieldBuilder.primaryKey()`
 
 Example:
 ```js
-field: FieldBuilder.number().output();
+field: FieldBuilder.number();
 
 // Output
 // field: {
@@ -369,7 +356,7 @@ Usage: `FieldBuilder.string()`
 
 Example:
 ```js
-field: FieldBuilder.string().output();
+field: FieldBuilder.string();
 
 // Output
 // field: {
@@ -385,7 +372,7 @@ Usage: `FieldBuilder.text()`
 
 Example:
 ```js
-field: FieldBuilder.text().output();
+field: FieldBuilder.text();
 
 // Output
 // field: {
@@ -461,7 +448,7 @@ Usage: `FieldBuilder.nonEmptyString()`
 
 Example:
 ```js
-field: new FieldBuilder().nonEmptyString().output();
+field: new FieldBuilder().nonEmptyString();
 
 // Output
 // field: {
@@ -477,7 +464,7 @@ Sets the field as allowing NULL as a value.  Depending on your SQL dialect, you 
 
 Example:
 ```js
-field: new FieldBuilder().optional().output();
+field: new FieldBuilder().optional();
 
 // Output
 // field: {
@@ -491,7 +478,7 @@ Sets the field as requiring a non-null value.  Depending on your SQL dialect, yo
 
 Example:
 ```js
-field: new FieldBuilder().required().output();
+field: new FieldBuilder().required();
 
 // Output
 // field: {
@@ -509,7 +496,7 @@ Example:
 ```js
 up(queryInstance, Sequelize) {
   await queryInterface.createTable('Users', {
-    id: new FieldBuilder().primaryKey().output();
+    id: new FieldBuilder().primaryKey();
 
     ...FieldBuilder.statusColumns()
   });
@@ -537,7 +524,7 @@ const { active, created_at, updated_at } = FieldBuilder.statusColumns();
 
 up(queryInstance, Sequelize) {
   await queryInterface.createTable('Users', {
-    id: new FieldBuilder().primaryKey().output();
+    id: new FieldBuilder().primaryKey();
 
     createdTimestamp: created_at,
     updatedTimestamp: updated_at
@@ -553,7 +540,7 @@ There are 2 forms of uniqueness.  The first one is column level uniqueness.  To 
 
 ```js
 
-field: new FieldBuilder().unique().output();
+field: new FieldBuilder().unique();
 
 // Output:
 //  {
@@ -565,7 +552,7 @@ field: new FieldBuilder().unique().output();
 Alternatively you can create named constraints by passing a string constraint name:
 
 ```js
-field: new FieldBuilder().unique('user_info').output();
+field: new FieldBuilder().unique('user_info');
 
 // Output:
 //  {
@@ -578,9 +565,9 @@ Named constraints can come in handy when you are building out tables that requir
 ```js
 up(queryInstance, Sequelize) {
   await queryInterface.createTable('Users', {
-    id: new FieldBuilder().primaryKey().output();
+    id: new FieldBuilder().primaryKey();
 
-    name: new FieldBuilder().string().unique('user_info').output()
+    name: new FieldBuilder().string().unique('user_info')
     email: new FieldBuilder().email().unique('user_info')
   });
 }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 const Sequelize = require('sequelize/lib/data-types');
 
 module.exports = class FieldBuilder {
-  fieldState = {};
 
   /**
    * Sets the type of a column as a boolean
    * @returns {FieldBuilder} The builder instance
    */
   boolean() {
-    Object.assign(this.fieldState, { type: Sequelize.BOOLEAN });
+    Object.assign(this, { type: Sequelize.BOOLEAN });
     return this;
   }
 
@@ -21,7 +20,7 @@ module.exports = class FieldBuilder {
       throw new Error('Invalid custom input');
     }
 
-    Object.assign(this.fieldState, input);
+    Object.assign(this, input);
 
     return this;
   }
@@ -31,7 +30,7 @@ module.exports = class FieldBuilder {
    * @returns {FieldBuilder} The builder instance 
    */
   date() {
-    Object.assign(this.fieldState, { type: Sequelize.DATE });
+    Object.assign(this, { type: Sequelize.DATE });
     return this;
   }
 
@@ -45,7 +44,7 @@ module.exports = class FieldBuilder {
       throw new Error('Default value must be defined')
     }
 
-    Object.assign(this.fieldState, { default: value });
+    Object.assign(this, { default: value });
     return this;
   }
 
@@ -54,7 +53,7 @@ module.exports = class FieldBuilder {
    * @returns {FieldBuilder} The builder instance
    */
   email() {
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.STRING
     });
 
@@ -62,10 +61,10 @@ module.exports = class FieldBuilder {
       isEmail: true,
     };
 
-    if (this.fieldState.validate) {
-      Object.assign(this.fieldState.validate, validate);
+    if (this.validate) {
+      Object.assign(this.validate, validate);
     } else {
-      Object.assign(this.fieldState, { validate });
+      Object.assign(this, { validate });
     }
 
     return this;
@@ -83,7 +82,7 @@ module.exports = class FieldBuilder {
       throw new Error('Enums cannot be empty');
     }
 
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.ENUM,
       values,
     });
@@ -101,7 +100,7 @@ module.exports = class FieldBuilder {
       throw new Error('A model name must be provided for a foreign key constraint');
     }
 
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.INTEGER,
       references: {
         model: {
@@ -124,7 +123,7 @@ module.exports = class FieldBuilder {
       throw new Error('Default value must be an object');
     }
 
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.JSON,
       default: defaultValue
     });
@@ -136,10 +135,10 @@ module.exports = class FieldBuilder {
    * @returns {FieldBuilder} The builder instance 
    */
   nonEmptyString() {
-    if (this.fieldState.validate) {
-      Object.assign(this.fieldState.validate, { notEmpty: true });
+    if (this.validate) {
+      Object.assign(this.validate, { notEmpty: true });
     } else {
-      Object.assign(this.fieldState, { validate: { notEmpty: true } });
+      Object.assign(this, { validate: { notEmpty: true } });
     }
 
     return this;
@@ -161,7 +160,7 @@ module.exports = class FieldBuilder {
 
     const type = typeMap[typeSelection] ?? typeMap.integer;
 
-    Object.assign(this.fieldState, { type });
+    Object.assign(this, { type });
     return this;
   }
 
@@ -170,12 +169,12 @@ module.exports = class FieldBuilder {
      * @returns {FieldBuilder} The builder instance
      */
   optional() {
-    Object.assign(this.fieldState, { allowNull: true });
+    Object.assign(this, { allowNull: true });
     return this;
   }
 
   output() {
-    return this.fieldState;
+    return this;
   }
 
   /**
@@ -183,7 +182,7 @@ module.exports = class FieldBuilder {
    * @returns {FieldBuilder} The builder instance 
    */
   primaryKey() {
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       allowNull: false,
       autoIncrement: true,
       primaryKey: true,
@@ -197,7 +196,7 @@ module.exports = class FieldBuilder {
    * @returns {FieldBuilder} The builder instance
    */
    required() {
-    Object.assign(this.fieldState, { allowNull: false });
+    Object.assign(this, { allowNull: false });
     return this;
   }
 
@@ -207,14 +206,14 @@ module.exports = class FieldBuilder {
    */
   static statusColumns() {
     return {
-      active: new FieldBuilder().boolean().output(),
-      created_at: new FieldBuilder().date().required().output(),
-      updated_at: new FieldBuilder().date().required().output(),
+      active: new FieldBuilder().boolean(),
+      created_at: new FieldBuilder().date().required(),
+      updated_at: new FieldBuilder().date().required(),
     }
   }
 
   string() {
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.STRING,
       default: "",
     });
@@ -222,7 +221,7 @@ module.exports = class FieldBuilder {
   }
 
   text() {
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       type: Sequelize.TEXT,
       default: "",
     });
@@ -238,7 +237,7 @@ module.exports = class FieldBuilder {
       throw new Error('Named constraints must be a string')
     }
     
-    Object.assign(this.fieldState, {
+    Object.assign(this, {
       unique: constraintName || true
     });
 

--- a/index.js
+++ b/index.js
@@ -173,7 +173,18 @@ module.exports = class FieldBuilder {
     return this;
   }
 
+  /**
+   * Returns the result of the builder.  
+   * 
+   * This feature is deprecated as the class instance itself now acts 
+   * as the internal record.  Keeping this around for now for backwards
+   * compatibility.  But this step is no longer required
+   * 
+   * @deprecated
+   * @returns 
+   */
   output() {
+    // TODO Set a release for the final removal of this feature
     return this;
   }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.BOOLEAN`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.boolean().output())
+      expect(builder.boolean())
         .to.deep.eq({ type: Sequelize.BOOLEAN })
     })
   });
@@ -22,7 +22,7 @@ describe('FieldBuilder', () => {
       const builder = new FieldBuilder();
       const customConfig = { type: Sequelize.JSONB }
 
-      expect(builder.customInput(customConfig).output())
+      expect(builder.customInput(customConfig))
         .to.deep.eq(customConfig);
     });
 
@@ -39,7 +39,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.DATE`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.date().output())
+      expect(builder.date())
         .to.deep.eq({ type: Sequelize.DATE })
     })
   });
@@ -48,7 +48,7 @@ describe('FieldBuilder', () => {
     it('should set the `defaultValue` to the provided input', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.defaultValue('N/A').output())
+      expect(builder.defaultValue('N/A'))
         .to.deep.eq({ default: 'N/A' });
     });
 
@@ -63,14 +63,14 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.STRING` and the email validation', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.email().output())
+      expect(builder.email())
         .to.deep.eq({ type: Sequelize.STRING, validate: { isEmail: true } });
     });
 
     it('should append to the validate object when one already exists', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.nonEmptyString().email().output())
+      expect(builder.nonEmptyString().email())
         .to.deep.eq({ type: Sequelize.STRING, validate: { notEmpty: true, isEmail: true } });
     });
   });
@@ -79,7 +79,7 @@ describe('FieldBuilder', () => {
     it('should accept a list of params and apply them', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.enum('pending', 'active', 'complete').output())
+      expect(builder.enum('pending', 'active', 'complete'))
         .to.deep.eq({ type: Sequelize.ENUM, values: [ 'pending', 'active', 'complete' ] });
     });
 
@@ -87,7 +87,7 @@ describe('FieldBuilder', () => {
       const builder = new FieldBuilder();
       const statusArray = ['pending', 'active', 'complete'];
 
-      expect(builder.enum(statusArray).output())
+      expect(builder.enum(statusArray))
         .to.deep.eq({ type: Sequelize.ENUM, values: [ 'pending', 'active', 'complete' ] });
     });
 
@@ -102,7 +102,7 @@ describe('FieldBuilder', () => {
     it('should accept a single parameter with the table name', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.foreignKey('Addresses').output())
+      expect(builder.foreignKey('Addresses'))
         .to.deep.eq({
           type: Sequelize.INTEGER,
           references: {
@@ -125,7 +125,7 @@ describe('FieldBuilder', () => {
     it('should accept 2 parameters for the table name and target column', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.foreignKey('User_Addresses', 'userId').output())
+      expect(builder.foreignKey('User_Addresses', 'userId'))
         .to.deep.eq({
           type: Sequelize.INTEGER,
           references: {
@@ -143,7 +143,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.JSON`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.json().output())
+      expect(builder.json())
         .to.deep.eq({ type: Sequelize.JSON, default: {} });
     });
 
@@ -181,14 +181,14 @@ describe('FieldBuilder', () => {
     it('should set `notEmpty` validator flag to true', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.nonEmptyString().output())
+      expect(builder.nonEmptyString())
         .to.deep.eq({ validate: { notEmpty: true } });
     });
 
     it('should append to the validate object when one already exists', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.email().nonEmptyString().output())
+      expect(builder.email().nonEmptyString())
         .to.deep.eq({ type: Sequelize.STRING, validate: { notEmpty: true, isEmail: true } });
     });
   });
@@ -197,42 +197,42 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.INTEGER`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number().output())
+      expect(builder.number())
         .to.deep.eq({ type: Sequelize.INTEGER })
     });
 
     it('should set the type of the field as `Sequelize.BIGINT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number('bigint').output())
+      expect(builder.number('bigint'))
         .to.deep.eq({ type: Sequelize.BIGINT })
     });
 
     it('should set the type of the field as `Sequelize.DOUBLE`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number('double').output())
+      expect(builder.number('double'))
         .to.deep.eq({ type: Sequelize.DOUBLE })
     });
     
     it('should set the type of the field as `Sequelize.FLOAT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number('float').output())
+      expect(builder.number('float'))
         .to.deep.eq({ type: Sequelize.FLOAT })
     });
 
     it('should set the type of the field as `Sequelize.INTEGER`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number('integer').output())
+      expect(builder.number('integer'))
         .to.deep.eq({ type: Sequelize.INTEGER })
     });
 
     it('should set the type of the field as `Sequelize.smallint`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.number('smallint').output())
+      expect(builder.number('smallint'))
         .to.deep.eq({ type: Sequelize.SMALLINT })
     });
     
@@ -242,7 +242,7 @@ describe('FieldBuilder', () => {
     it('should configure the field to allow NULL', () => {
       const falsyBuilder = new FieldBuilder();
 
-      const falsyField = falsyBuilder.optional().output();
+      const falsyField = falsyBuilder.optional();
 
 
       expect(falsyField).to.deep.eq({ allowNull: true })
@@ -254,7 +254,7 @@ describe('FieldBuilder', () => {
     it('should provide the primary key configurations', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.primaryKey().output())
+      expect(builder.primaryKey())
         .to.deep.eq({ type: Sequelize.INTEGER, allowNull: false, autoIncrement: true, primaryKey: true })
     })
   });
@@ -263,7 +263,7 @@ describe('FieldBuilder', () => {
     it('should configure the field to NOT allow NULL', () => {
       const falsyBuilder = new FieldBuilder();
 
-      const falsyField = falsyBuilder.required().output();
+      const falsyField = falsyBuilder.required();
 
 
       expect(falsyField).to.deep.eq({ allowNull: false })
@@ -285,7 +285,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.STRING`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.string().output())
+      expect(builder.string())
         .to.deep.eq({ type: Sequelize.STRING, default: "" })
     })
   });
@@ -294,7 +294,7 @@ describe('FieldBuilder', () => {
     it('should set the type of the field as `Sequelize.TEXT`', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.text().output())
+      expect(builder.text())
         .to.deep.eq({ type: Sequelize.TEXT, default: "" })
     })
   });
@@ -303,14 +303,14 @@ describe('FieldBuilder', () => {
     it('should set the unique flag to true', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.unique().output())
+      expect(builder.unique())
         .to.deep.eq({ unique: true })
     })
 
     it('should set the unique flag to the input value', () => {
       const builder = new FieldBuilder();
 
-      expect(builder.unique('user_info').output())
+      expect(builder.unique('user_info'))
         .to.deep.eq({ unique: 'user_info' })
     })
 


### PR DESCRIPTION
**Description**

Removes the requirement that the builder call `output()` to get the configuration out.   The class itself can act as the record.  